### PR TITLE
Fix file open for relative paths.

### DIFF
--- a/lib/ip2location_ruby.rb
+++ b/lib/ip2location_ruby.rb
@@ -12,7 +12,7 @@ class Ip2location
   attr_accessor :record_class4, :record_class6, :v4, :file, :db_index, :count, :base_addr, :ipno, :count, :record, :database, :columns, :ip_version, :ipv4databasecount, :ipv4databaseaddr, :ipv4indexbaseaddr, :ipv6databasecount, :ipv6databaseaddr, :ipv6indexbaseaddr
   
   def open(url)
-    self.file = File.open(File.expand_path url, 'rb')
+    self.file = File.open(File.expand_path(url), 'rb')
     i2l = Ip2locationConfig.read(file)
     self.db_index = i2l.databasetype
     self.columns = i2l.databasecolumn + 0


### PR DESCRIPTION
Without parentheses, `File.open(File.expand_path url, 'rb')` is translated into `File.open(File.expand_path(url, 'rb'))`, which will insert './rb/' in the middle of the resulting path if url is a relative path. That is wrong and causes a file-not-found error.
It doesn't make problems when url is an absolute path, because 'rb' is silently ignored by File.expand_path and File.open takes the default value 'r' as the mode.
