### PR TITLE
Silence Warnings (again)

### DIFF
--- a/lib/ip2location_ruby.rb
+++ b/lib/ip2location_ruby.rb
@@ -12,7 +12,7 @@ require 'ip2location_ruby/i2l_ip_data'
 require 'ip2location_ruby/ip2location_record'
 
 class Ip2location
-  attr_accessor :record_class4, :record_class6, :v4, :file, :db_index, :count, :base_addr, :ipno, :count, :record, :database, :columns, :ip_version, :ipv4databasecount, :ipv4databaseaddr, :ipv4indexbaseaddr, :ipv6databasecount, :ipv6databaseaddr, :ipv6indexbaseaddr, :databaseyear, :databasemonth, :databaseday, :last_err_msg
+  attr_accessor :record_class4, :record_class6, :v4, :file, :db_index, :count, :base_addr, :ipno, :record, :database, :columns, :ip_version, :ipv4databasecount, :ipv4databaseaddr, :ipv4indexbaseaddr, :ipv6databasecount, :ipv6databaseaddr, :ipv6indexbaseaddr, :databaseyear, :databasemonth, :databaseday, :last_err_msg
 
   VERSION = '8.7.2'
   FIELD_NOT_SUPPORTED = 'NOT SUPPORTED'


### PR DESCRIPTION
I was just seeing a few more warnings in Geocoder test runs. The `:count` method appears to have been accidentally duplicated when calling `attr_accessor`.